### PR TITLE
user query

### DIFF
--- a/src/apollo/schema.gql
+++ b/src/apollo/schema.gql
@@ -1,17 +1,14 @@
-type Example {
-  id: ID!
+type User {
+  age: String
+  birthday: String
   name: String!
-  message: String!
-}
-
-type Sample {
-  id: ID!
-  title: String!
-  status: String!
+  displayName: String!
+  email: String!
+  uid: ID!
+  weight: String!
 }
 type Query {
-  examples: [Example]
-  samples: [Sample]
+  users: [User]
 }
 
 type Mutation {

--- a/src/entity/example/document.gql
+++ b/src/entity/example/document.gql
@@ -1,5 +1,0 @@
-fragment ExampleUnit on Example {
-  id
-  name
-  message
-}

--- a/src/entity/sample/document.gql
+++ b/src/entity/sample/document.gql
@@ -1,5 +1,0 @@
-fragment SampleUnit on Sample {
-  id
-  title
-  status
-}

--- a/src/entity/user/document.gql
+++ b/src/entity/user/document.gql
@@ -1,0 +1,9 @@
+fragment UserUnit on User {
+  uid
+  name
+  displayName
+  age
+  birthday
+  email
+  weight
+}

--- a/src/screens/home/home/document.gql
+++ b/src/screens/home/home/document.gql
@@ -1,13 +1,6 @@
-query fetchSamplesAndExamples {
-  examples {
-    id
-    name
-    message
-  }
-
-  samples {
-    id
-    title
-    status
+query FetchUsers {
+  users {
+    uid
+    displayName
   }
 }

--- a/src/screens/home/home/screen.component.tsx
+++ b/src/screens/home/home/screen.component.tsx
@@ -1,14 +1,12 @@
-import React, {FC, useState} from 'react';
+import React, {FC, useEffect, useState} from 'react';
 import styled from 'styled-components/native';
 import {useTranslation} from 'react-i18next';
-import {Button} from 'react-native';
+import {Button, View} from 'react-native';
 import AppleHealthKit, {
   HealthValue,
   HealthKitPermissions,
 } from 'react-native-health';
-import { usefetchSamplesAndExamplesQuery } from './document.gen'
-import {ExampleUnitFragment} from '@src/entity/example/document.gen'
-import { SampleUnitFragment } from '@src/entity/sample/document.gen';
+import {useFetchUsersQuery} from './document.gen'
 
 /* Permission options */
 const permissions = {
@@ -42,13 +40,26 @@ AppleHealthKit.initHealthKit(permissions, (error: string) => {
 
 const ScreenComponent: FC = () => {
 
-  const {data, loading} = usefetchSamplesAndExamplesQuery()
+  const {data, loading} = useFetchUsersQuery()
 
-  const samples = data?.samples ?? []
+  useEffect(() => {
+
+    if(!loading)  {
+      console.log(data)
+    }
+  }, [loading])
 
   return (
     <Wrapper>
       <TestText>test success!</TestText>
+      {data?.users?.map((user, index) => {
+        return (
+          <View key={index}>
+          <TestText>{user?.uid}</TestText>
+          <TestText>{user?.displayName}</TestText>
+          </View>
+        )
+      })}
     </Wrapper>
   );
 };

--- a/src/types/graphql.gen.ts
+++ b/src/types/graphql.gen.ts
@@ -13,13 +13,6 @@ export type Scalars = {
   Float: number;
 };
 
-export type Example = {
-  __typename?: 'Example';
-  id: Scalars['ID'];
-  message: Scalars['String'];
-  name: Scalars['String'];
-};
-
 export type Mutation = {
   __typename?: 'Mutation';
   _empty: Maybe<Scalars['String']>;
@@ -27,15 +20,18 @@ export type Mutation = {
 
 export type Query = {
   __typename?: 'Query';
-  examples: Maybe<Array<Maybe<Example>>>;
-  samples: Maybe<Array<Maybe<Sample>>>;
+  users: Maybe<Array<Maybe<User>>>;
 };
 
-export type Sample = {
-  __typename?: 'Sample';
-  id: Scalars['ID'];
-  status: Scalars['String'];
-  title: Scalars['String'];
+export type User = {
+  __typename?: 'User';
+  age: Maybe<Scalars['String']>;
+  birthday: Maybe<Scalars['String']>;
+  displayName: Scalars['String'];
+  email: Scalars['String'];
+  name: Scalars['String'];
+  uid: Scalars['ID'];
+  weight: Scalars['String'];
 };
 
 
@@ -108,30 +104,21 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Example: ResolverTypeWrapper<Example>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   Mutation: ResolverTypeWrapper<{}>;
   Query: ResolverTypeWrapper<{}>;
-  Sample: ResolverTypeWrapper<Sample>;
   String: ResolverTypeWrapper<Scalars['String']>;
+  User: ResolverTypeWrapper<User>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Boolean: Scalars['Boolean'];
-  Example: Example;
   ID: Scalars['ID'];
   Mutation: {};
   Query: {};
-  Sample: Sample;
   String: Scalars['String'];
-};
-
-export type ExampleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Example'] = ResolversParentTypes['Example']> = {
-  id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  message: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  name: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+  User: User;
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
@@ -139,21 +126,23 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  examples: Resolver<Maybe<Array<Maybe<ResolversTypes['Example']>>>, ParentType, ContextType>;
-  samples: Resolver<Maybe<Array<Maybe<ResolversTypes['Sample']>>>, ParentType, ContextType>;
+  users: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
 };
 
-export type SampleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Sample'] = ResolversParentTypes['Sample']> = {
-  id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  status: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  title: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  age: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  birthday: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  displayName: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  email: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  uid: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  weight: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = any> = {
-  Example: ExampleResolvers<ContextType>;
   Mutation: MutationResolvers<ContextType>;
   Query: QueryResolvers<ContextType>;
-  Sample: SampleResolvers<ContextType>;
+  User: UserResolvers<ContextType>;
 };
 


### PR DESCRIPTION
## 概要

Cloud Functionsで以下のように定義
```ts
const typeDefs = gql`
  type Query {
    users: [User]
  }

  type User {
    age: String
    birthday: String
    displayName: String!
    email: String!
    uid: ID!
    weight: String!
  }
`;

const resolvers = {
  Query: {
    async users() {
      const users = await admin.firestore().collection("users").get();
      return users.docs.map((user) => user.data());
    },
  },
};

```

上記記載後、`functions`ディレクトリで`npm run build`し、親ディレクトリ に戻って`firebase serve`。
これでエンドポイントとなるローカルホストが立ち上がる。

同様の定義をRN側の`src/apollo/schema.gql`に記載。そしてusersをfetchするgqlを定義して`yarn graphql-codegen`し、カスタムhookを生成し、コンポーネント側で使用
```ts
import {useFetchUsersQuery} from './document.gen'
```

## 実装内容

* このプルリクで追加（または修正）した機能
* UIに変更がある際はスクショも添付

## 動作確認

* 行った動作確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）